### PR TITLE
LWB-48: Persist normalized content (articles, sections, media) + endpoints

### DIFF
--- a/docs/copilot-recent-memory.md
+++ b/docs/copilot-recent-memory.md
@@ -15,7 +15,8 @@ Notes:
 - MANIFEST_SECRET gates manifest emission by design.
 
 Recent:
-- LWB-47 PR merged; remote feature branch deleted by user. Local cleanup done: committed local edits, switched to main, deleted local branch, pruned remotes.
+- LWB-47 PR merged; local cleanup complete.
+- Started LWB-48 on branch feature/LWB-48-persist. Implemented server persistence layer with in-memory/PG store, wired ingestion to save article, added endpoints: GET /v1/articles/manifest and GET /v1/articles/:id. All server tests pass (12/12).
 
 Next:
 - Decide on immediate task: lightweight tests for SearchViewModel or start next Jira ticket.

--- a/docs/copilot-recent-memory.md
+++ b/docs/copilot-recent-memory.md
@@ -1,5 +1,5 @@
 Date: 2025-09-10
-Branch: feature/LWB-47-search
+Branch: main
 
 Completed (server):
 - LWB-51: Signed manifest builder (checksum + HMAC) implemented; optional manifest returned by /v1/ingest/docx when MANIFEST_SECRET is set.
@@ -14,5 +14,8 @@ Notes:
 - No TODO/FIXME markers in server/src related to LWB-46/51/52.
 - MANIFEST_SECRET gates manifest emission by design.
 
+Recent:
+- LWB-47 PR merged; remote feature branch deleted by user. Local cleanup done: committed local edits, switched to main, deleted local branch, pruned remotes.
+
 Next:
-- LWB-47: Navigation wired. Consider adding UI tests for SearchViewModel behavior and polish (snippets/highlighting). Prepare PR.
+- Decide on immediate task: lightweight tests for SearchViewModel or start next Jira ticket.

--- a/server/src/buildServer.ts
+++ b/server/src/buildServer.ts
@@ -7,6 +7,7 @@ import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { buildUserStore } from './userStore.js';
 import { createChallenge, verifySolution } from 'altcha-lib';
+import { buildContentStore, computeChecksumForNormalized } from './contentStore.js';
 
 export interface ArticleManifestItem {
   id: string; title: string; slug: string; version: number; updatedAt: string; wordCount: number;
@@ -63,6 +64,7 @@ export function buildServer(opts: BuildServerOptions): FastifyInstance {
   const revocations = opts.revocations ?? new InMemoryRevocationStore();
   const jwtSecret = opts.jwtSecret || process.env.PWD_JWT_SECRET || 'DEV_ONLY_CHANGE_ME';
   const users = buildUserStore();
+  const content = buildContentStore();
   app.log.info({ event: 'user_store_selected', impl: users.constructor.name }, 'User store initialized');
   // ALTCHA configuration
   const ALTCHA_HMAC_KEY = process.env.ALTCHA_HMAC_KEY || process.env.PWD_JWT_SECRET || 'ALTCHA_DEV_ONLY_CHANGE_ME';
@@ -81,7 +83,18 @@ export function buildServer(opts: BuildServerOptions): FastifyInstance {
     return reply.code(200).send(challenge);
   });
 
-  // NOTE: Article list/manifest endpoint will be implemented when persistence is added (LWB-48).
+  // LWB-48: Article manifests list and fetch
+  app.get('/v1/articles/manifest', async (_req, reply) => {
+    const items = await content.listManifests();
+    return reply.code(200).send({ items });
+  });
+
+  app.get('/v1/articles/:id', async (req, reply) => {
+    const id = (req.params as { id: string }).id;
+    const art = await content.getArticle(id);
+    if (!art) return reply.code(404).send({ error: 'not_found' });
+    return reply.code(200).send(art);
+  });
 
   app.post('/v1/auth/validate', async (req, reply) => {
     const bodySchema = z.object({ idToken: z.string().min(10) });
@@ -202,17 +215,37 @@ export function buildServer(opts: BuildServerOptions): FastifyInstance {
       const { parseDocx } = await import('./ingestion/docx.js');
       const parsed = await parseDocx(tmp, { withHtml: true });
       try { await fs.unlink(tmp); } catch { /* ignore */ }
-      const base = { wordCount: parsed.wordCount, sections: parsed.sections.length, media: parsed.media.length };
+      // Derive title from first heading or filename; id/slug from title
+      const firstHeading = parsed.sections.find(s => s.kind === 'heading' && s.text?.trim());
+      const filename = (filePart as { filename?: string })?.filename;
+      const baseTitle = firstHeading?.text?.trim() || (filename ? filename.replace(/\.[^.]+$/, '') : 'Untitled');
+      const slug = baseTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 80) || 'untitled';
+      const title = baseTitle.slice(0, 140);
+      const version = 1; // MVP; later from request or store
+      // Build normalized checksum (manifest-like)
+      const checksum = computeChecksumForNormalized({ id: slug, version, sections: parsed.sections, media: parsed.media });
       const secret = process.env.MANIFEST_SECRET;
+      const signature = secret ? (await import('crypto')).then(({ default: crypto }) => crypto.createHmac('sha256', secret).update(checksum).digest('hex')) : Promise.resolve<string | undefined>(undefined);
+      const sig = await signature;
+      // Persist
+      await content.upsertArticle({
+        id: slug,
+        slug,
+        title,
+        version,
+        wordCount: parsed.wordCount,
+        sections: parsed.sections.map((s, idx) => ({ order: idx, kind: s.kind as any, level: s.level, text: s.text, html: s.html, mediaRefId: s.mediaRefId })),
+        media: parsed.media.map(m => ({ id: m.id, type: m.type, filename: m.filename, contentType: m.contentType, src: m.src, checksum: m.checksum })),
+        checksum,
+        signature: sig,
+        html: parsed.html,
+        text: parsed.text,
+      });
+      const base = { wordCount: parsed.wordCount, sections: parsed.sections.length, media: parsed.media.length };
+      // Return manifest if secret exists (as before)
       if (secret) {
-        // Derive title from first heading or filename; id as a simple slug of title
-        const firstHeading = parsed.sections.find(s => s.kind === 'heading' && s.text?.trim());
-        const filename = (filePart as { filename?: string })?.filename;
-        const baseTitle = firstHeading?.text?.trim() || (filename ? filename.replace(/\.[^.]+$/, '') : 'Untitled');
-        const slug = baseTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 80) || 'untitled';
-        const title = baseTitle.slice(0, 140);
         const { buildManifest } = await import('./ingestion/manifest.js');
-        const manifest = buildManifest({ id: slug, title, version: 1, sections: parsed.sections, media: parsed.media, wordCount: parsed.wordCount }, secret);
+        const manifest = buildManifest({ id: slug, title, version, sections: parsed.sections, media: parsed.media, wordCount: parsed.wordCount }, secret);
         return reply.code(200).send({ ...base, manifest });
       }
       return reply.code(200).send(base);

--- a/server/src/buildServer.ts
+++ b/server/src/buildServer.ts
@@ -8,6 +8,7 @@ import bcrypt from 'bcryptjs';
 import { buildUserStore } from './userStore.js';
 import { createChallenge, verifySolution } from 'altcha-lib';
 import { buildContentStore, computeChecksumForNormalized } from './contentStore.js';
+import type { SectionKind } from './contentStore.js';
 import crypto from 'crypto';
 
 export interface ArticleManifestItem {
@@ -234,7 +235,7 @@ export function buildServer(opts: BuildServerOptions): FastifyInstance {
         title,
         version,
         wordCount: parsed.wordCount,
-        sections: parsed.sections.map((s, idx) => ({ order: idx, kind: s.kind as any, level: s.level, text: s.text, html: s.html, mediaRefId: s.mediaRefId })),
+        sections: parsed.sections.map((s, idx) => ({ order: idx, kind: s.kind as SectionKind, level: s.level, text: s.text, html: s.html, mediaRefId: s.mediaRefId })),
         media: parsed.media.map(m => ({ id: m.id, type: m.type, filename: m.filename, contentType: m.contentType, src: m.src, checksum: m.checksum })),
         checksum,
         signature: sig,

--- a/server/src/buildServer.ts
+++ b/server/src/buildServer.ts
@@ -8,6 +8,7 @@ import bcrypt from 'bcryptjs';
 import { buildUserStore } from './userStore.js';
 import { createChallenge, verifySolution } from 'altcha-lib';
 import { buildContentStore, computeChecksumForNormalized } from './contentStore.js';
+import crypto from 'crypto';
 
 export interface ArticleManifestItem {
   id: string; title: string; slug: string; version: number; updatedAt: string; wordCount: number;
@@ -224,9 +225,8 @@ export function buildServer(opts: BuildServerOptions): FastifyInstance {
       const version = 1; // MVP; later from request or store
       // Build normalized checksum (manifest-like)
       const checksum = computeChecksumForNormalized({ id: slug, version, sections: parsed.sections, media: parsed.media });
-      const secret = process.env.MANIFEST_SECRET;
-      const signature = secret ? (await import('crypto')).then(({ default: crypto }) => crypto.createHmac('sha256', secret).update(checksum).digest('hex')) : Promise.resolve<string | undefined>(undefined);
-      const sig = await signature;
+  const secret = process.env.MANIFEST_SECRET;
+  const sig = secret ? crypto.createHmac('sha256', secret).update(checksum).digest('hex') : undefined;
       // Persist
       await content.upsertArticle({
         id: slug,

--- a/server/src/contentStore.ts
+++ b/server/src/contentStore.ts
@@ -151,6 +151,8 @@ export class PostgresContentStore implements ContentStore {
       const artRow = a.rows[0];
       const secs = await c.query('SELECT ord, kind, level, text, html, media_ref_id FROM article_sections WHERE article_id=$1 ORDER BY ord', [id]);
       const media = await c.query('SELECT id, type, filename, content_type, src, checksum FROM media_assets WHERE article_id=$1', [id]);
+      type SectionRow = { ord: number | string; kind: SectionKind; level: number | null; text: string | null; html: string | null; media_ref_id: string | null };
+      type MediaRow = { id: string; type: MediaRecord['type']; filename: string | null; content_type: string | null; src: string | null; checksum: string | null };
       return {
         id: artRow.id,
         slug: artRow.slug,
@@ -163,8 +165,8 @@ export class PostgresContentStore implements ContentStore {
         text: artRow.text,
         createdAt: artRow.created_at.toISOString?.() || artRow.created_at,
         updatedAt: artRow.updated_at.toISOString?.() || artRow.updated_at,
-        sections: secs.rows.map((r: any) => ({ order: Number(r.ord), kind: r.kind, level: r.level, text: r.text, html: r.html, mediaRefId: r.media_ref_id })),
-        media: media.rows.map((r: any) => ({ id: r.id, type: r.type, filename: r.filename, contentType: r.content_type, src: r.src, checksum: r.checksum }))
+        sections: (secs.rows as SectionRow[]).map((r) => ({ order: Number(r.ord), kind: r.kind, level: r.level ?? undefined, text: r.text ?? undefined, html: r.html ?? undefined, mediaRefId: r.media_ref_id ?? undefined })),
+        media: (media.rows as MediaRow[]).map((r) => ({ id: r.id, type: r.type, filename: r.filename ?? undefined, contentType: r.content_type ?? undefined, src: r.src ?? undefined, checksum: r.checksum ?? undefined }))
       } as StoredArticle;
     });
   }

--- a/server/src/contentStore.ts
+++ b/server/src/contentStore.ts
@@ -1,0 +1,187 @@
+import crypto from 'crypto';
+import { Pool, PoolClient } from 'pg';
+
+export type SectionKind = 'heading' | 'paragraph' | 'list' | 'quote' | 'image' | 'audio' | 'video' | 'embed';
+
+export interface ArticleRecord {
+  id: string;
+  slug: string;
+  title: string;
+  version: number;
+  wordCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SectionRecord {
+  order: number;
+  kind: SectionKind;
+  level?: number | null;
+  text?: string | null;
+  html?: string | null;
+  mediaRefId?: string | null;
+}
+
+export interface MediaRecord {
+  id: string;
+  type: 'image' | 'audio' | 'video' | 'embed';
+  filename?: string | null;
+  contentType?: string | null;
+  src?: string | null;
+  checksum?: string | null;
+}
+
+export interface StoredArticle extends ArticleRecord {
+  sections: SectionRecord[];
+  media: MediaRecord[];
+  checksum: string; // checksum over normalized content
+  signature?: string | null;
+  html?: string | null; // optional consolidated sanitized HTML
+  text?: string | null; // optional consolidated plain text
+}
+
+export interface ContentStore {
+  upsertArticle(article: Omit<StoredArticle, 'createdAt'|'updatedAt'>): Promise<void>;
+  listManifests(): Promise<Pick<ArticleRecord,'id'|'title'|'slug'|'version'|'updatedAt'|'wordCount'>[]>;
+  getArticle(id: string): Promise<StoredArticle | undefined>;
+}
+
+// In-memory implementation for tests/dev
+export class InMemoryContentStore implements ContentStore {
+  private byId = new Map<string, StoredArticle>();
+  async upsertArticle(article: Omit<StoredArticle, 'createdAt'|'updatedAt'>): Promise<void> {
+    const now = new Date().toISOString();
+    const existing = this.byId.get(article.id);
+    const record: StoredArticle = { ...article, createdAt: existing?.createdAt ?? now, updatedAt: now };
+    this.byId.set(article.id, record);
+  }
+  async listManifests() { return Array.from(this.byId.values()).map(a => ({ id: a.id, title: a.title, slug: a.slug, version: a.version, updatedAt: a.updatedAt, wordCount: a.wordCount })); }
+  async getArticle(id: string) { return this.byId.get(id); }
+}
+
+// Postgres implementation
+export class PostgresContentStore implements ContentStore {
+  private pool: Pool;
+  private initPromise: Promise<void> | null = null;
+  constructor(private url: string) { this.pool = new Pool({ connectionString: url, ssl: this.sslConfig(url) }); }
+  private sslConfig(url: string) {
+    if (/localhost|127.0.0.1/.test(url)) return false;
+    if (process.env.DB_SSL_DISABLE === '1') return false;
+    return { rejectUnauthorized: false };
+  }
+  private async withClient<T>(fn: (c: PoolClient) => Promise<T>): Promise<T> { const c = await this.pool.connect(); try { return await fn(c); } finally { c.release(); } }
+  private async ensureSchema() {
+    if (!this.initPromise) {
+      this.initPromise = this.withClient(async (c) => {
+        await c.query(`CREATE TABLE IF NOT EXISTS articles (
+          id TEXT PRIMARY KEY,
+          slug TEXT NOT NULL,
+          title TEXT NOT NULL,
+          version INTEGER NOT NULL,
+          word_count INTEGER NOT NULL,
+          checksum TEXT NOT NULL,
+          signature TEXT,
+          html TEXT,
+          text TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        );`);
+        await c.query(`CREATE TABLE IF NOT EXISTS article_sections (
+          article_id TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+          ord INTEGER NOT NULL,
+          kind TEXT NOT NULL,
+          level INTEGER,
+          text TEXT,
+          html TEXT,
+          media_ref_id TEXT,
+          PRIMARY KEY(article_id, ord)
+        );`);
+        await c.query(`CREATE TABLE IF NOT EXISTS media_assets (
+          article_id TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+          id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          filename TEXT,
+          content_type TEXT,
+          src TEXT,
+          checksum TEXT,
+          PRIMARY KEY(article_id, id)
+        );`);
+      });
+    }
+    return this.initPromise;
+  }
+  async upsertArticle(article: Omit<StoredArticle, 'createdAt'|'updatedAt'>): Promise<void> {
+    await this.ensureSchema();
+    await this.withClient(async (c) => {
+      await c.query('BEGIN');
+      try {
+        await c.query(`INSERT INTO articles (id, slug, title, version, word_count, checksum, signature, html, text)
+          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+          ON CONFLICT (id) DO UPDATE SET slug=EXCLUDED.slug, title=EXCLUDED.title, version=EXCLUDED.version, word_count=EXCLUDED.word_count, checksum=EXCLUDED.checksum, signature=EXCLUDED.signature, html=EXCLUDED.html, text=EXCLUDED.text, updated_at=now()`,
+          [article.id, article.slug, article.title, article.version, article.wordCount, article.checksum, article.signature ?? null, article.html ?? null, article.text ?? null]);
+        await c.query('DELETE FROM article_sections WHERE article_id=$1', [article.id]);
+        for (const s of article.sections) {
+          await c.query('INSERT INTO article_sections (article_id, ord, kind, level, text, html, media_ref_id) VALUES ($1,$2,$3,$4,$5,$6,$7)',
+            [article.id, s.order, s.kind, s.level ?? null, s.text ?? null, s.html ?? null, s.mediaRefId ?? null]);
+        }
+        await c.query('DELETE FROM media_assets WHERE article_id=$1', [article.id]);
+        for (const m of article.media) {
+          await c.query('INSERT INTO media_assets (article_id, id, type, filename, content_type, src, checksum) VALUES ($1,$2,$3,$4,$5,$6,$7)',
+            [article.id, m.id, m.type, m.filename ?? null, m.contentType ?? null, m.src ?? null, m.checksum ?? null]);
+        }
+        await c.query('COMMIT');
+      } catch (e) {
+        await c.query('ROLLBACK');
+        throw e;
+      }
+    });
+  }
+  async listManifests() {
+    await this.ensureSchema();
+    return this.withClient(async (c) => {
+      const res = await c.query('SELECT id, title, slug, version, word_count, updated_at FROM articles ORDER BY updated_at DESC');
+      return res.rows.map(r => ({ id: r.id, title: r.title, slug: r.slug, version: Number(r.version), updatedAt: r.updated_at.toISOString?.() || r.updated_at, wordCount: Number(r.word_count) }));
+    });
+  }
+  async getArticle(id: string) {
+    await this.ensureSchema();
+    return this.withClient(async (c) => {
+      const a = await c.query('SELECT id, slug, title, version, word_count, checksum, signature, html, text, created_at, updated_at FROM articles WHERE id=$1', [id]);
+      if (!a.rowCount) return undefined;
+      const artRow = a.rows[0];
+      const secs = await c.query('SELECT ord, kind, level, text, html, media_ref_id FROM article_sections WHERE article_id=$1 ORDER BY ord', [id]);
+      const media = await c.query('SELECT id, type, filename, content_type, src, checksum FROM media_assets WHERE article_id=$1', [id]);
+      return {
+        id: artRow.id,
+        slug: artRow.slug,
+        title: artRow.title,
+        version: Number(artRow.version),
+        wordCount: Number(artRow.word_count),
+        checksum: artRow.checksum,
+        signature: artRow.signature,
+        html: artRow.html,
+        text: artRow.text,
+        createdAt: artRow.created_at.toISOString?.() || artRow.created_at,
+        updatedAt: artRow.updated_at.toISOString?.() || artRow.updated_at,
+        sections: secs.rows.map((r: any) => ({ order: Number(r.ord), kind: r.kind, level: r.level, text: r.text, html: r.html, mediaRefId: r.media_ref_id })),
+        media: media.rows.map((r: any) => ({ id: r.id, type: r.type, filename: r.filename, contentType: r.content_type, src: r.src, checksum: r.checksum }))
+      } as StoredArticle;
+    });
+  }
+}
+
+export function buildContentStore(): ContentStore {
+  const url = process.env.DATABASE_URL;
+  if (url && process.env.NODE_ENV !== 'test') return new PostgresContentStore(url);
+  return new InMemoryContentStore();
+}
+
+export function computeChecksumForNormalized(input: { sections: { kind: string; level?: number; text?: string; mediaRefId?: string | null }[]; media: { type: string; filename?: string | null; checksum?: string | null; src?: string | null }[]; version: number; id: string; }): string {
+  const normalized = JSON.stringify({
+    id: input.id,
+    version: input.version,
+    sections: input.sections.map(s => ({ k: s.kind, l: s.level, t: s.text, m: s.mediaRefId ?? null })),
+    media: input.media.map(m => ({ t: m.type, f: m.filename ?? null, c: m.checksum ?? null, s: m.src ?? null })),
+  });
+  return crypto.createHash('sha256').update(normalized).digest('hex');
+}

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { buildServer, InMemoryRevocationStore } from './buildServer.js';
+import type { ArticleManifestItem } from './buildServer.js';
 import type { FastifyInstance } from 'fastify';
 
 let app: FastifyInstance;
@@ -133,7 +134,7 @@ describe('ingestion endpoint', () => {
     expect(list.statusCode).toBe(200);
     const listBody = list.json();
     expect(Array.isArray(listBody.items)).toBe(true);
-    const item = listBody.items.find((it: any) => it.id === 't' || it.slug === 't');
+  const item = listBody.items.find((it: ArticleManifestItem) => it.id === 't' || it.slug === 't');
     // depending on slug derivation, it should include something similar
     expect(listBody.items.length).toBeGreaterThan(0);
     // fetch first item

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -8,7 +8,7 @@ const googleClientId = 'test-client';
 
 // Mock ingestion module globally for ESM to avoid heavy processing during tests
 vi.mock('./ingestion/docx.js', () => ({
-  parseDocx: async () => ({ sections: [{ kind: 'heading', level: 1, text: 'T' }], media: [], wordCount: 3 })
+  parseDocx: async () => ({ sections: [{ kind: 'heading', level: 1, text: 'T' }, { kind: 'paragraph', text: 'Hello' }], media: [], wordCount: 3, html: '<h1>T</h1><p>Hello</p>', text: 'T Hello' })
 }));
 
 // naive stub of google-auth-library by monkey-patching global import cache
@@ -119,11 +119,30 @@ describe('ingestion endpoint', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.wordCount).toBe(3);
-    expect(body.sections).toBe(1);
+  expect(body.sections).toBe(2);
     // manifest is optional based on env
     if (body.manifest) {
       expect(body.manifest.checksum).toBeTruthy();
       expect(body.manifest.signature).toBeTruthy();
     }
+  });
+
+  test('after ingest, manifests list includes the article and article is retrievable', async () => {
+    // list manifests
+    const list = await app.inject({ method: 'GET', url: '/v1/articles/manifest' });
+    expect(list.statusCode).toBe(200);
+    const listBody = list.json();
+    expect(Array.isArray(listBody.items)).toBe(true);
+    const item = listBody.items.find((it: any) => it.id === 't' || it.slug === 't');
+    // depending on slug derivation, it should include something similar
+    expect(listBody.items.length).toBeGreaterThan(0);
+    // fetch first item
+    const id = (item?.id) ?? listBody.items[0].id;
+    const get = await app.inject({ method: 'GET', url: `/v1/articles/${id}` });
+    expect(get.statusCode).toBe(200);
+    const article = get.json();
+    expect(article.id).toBeTruthy();
+    expect(article.sections?.length).toBeGreaterThan(0);
+    expect(article.wordCount).toBe(3);
   });
 });

--- a/server/src/ingestion/docx.ts
+++ b/server/src/ingestion/docx.ts
@@ -82,7 +82,7 @@ export async function parseDocx(filePath: string, opts: ParseDocxOptions = {}): 
       images.push({ type: 'audio', id, src: href, checksum: checksum(Buffer.from(href, 'utf8')) });
     }
   }
-  return { sections, media: images, wordCount: words.length };
+  return { sections, media: images, wordCount: words.length, html, text: textOnly };
 }
 
 export async function extractMedia(filePath: string): Promise<ExtractedMediaItem[]> {

--- a/server/src/ingestion/docxTypes.ts
+++ b/server/src/ingestion/docxTypes.ts
@@ -25,5 +25,7 @@ export interface ParsedDocxResult {
   sections: ParsedDocxSection[];
   media: ExtractedMediaItem[];
   wordCount: number;
+  html?: string; // sanitized HTML when requested
+  text?: string; // plain text extracted from document
   // Optional consolidated sanitized HTML or text can be added later if needed
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
   "skipLibCheck": true,
-  "types": ["vitest"]
+  "types": ["vitest", "node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Implements ContentStore (in-memory + Postgres), wires ingestion to persist sanitized HTML/text/sections/media with checksum/signature, and adds GET /v1/articles/manifest and GET /v1/articles/:id. Includes tests (12/12 pass).